### PR TITLE
Default loggers constraints

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <RootNamespace>Byndyusoft.Logging</RootNamespace>
     <Authors>Byndyusoft</Authors>
     <PackageTags>Byndyusoft;Logging;Serilog</PackageTags>

--- a/src/Byndyusoft.Logging/Configuration/LoggerConfigurationExtensions.cs
+++ b/src/Byndyusoft.Logging/Configuration/LoggerConfigurationExtensions.cs
@@ -56,7 +56,7 @@ namespace Byndyusoft.Logging.Configuration
 
         public static LoggerConfiguration OverrideDefaultLoggers(
             this LoggerConfiguration loggerConfiguration,
-            LogEventLevel microsoft = LogEventLevel.Fatal,
+            LogEventLevel microsoft = LogEventLevel.Error,
             LogEventLevel system = LogEventLevel.Warning,
             LogEventLevel microsoftHostingLifetime = LogEventLevel.Information)
         {


### PR DESCRIPTION
In ASP.NET Core by default errors produced by middlewares' pipeline are logged via `Microsoft` logger, so errors from it ought to be preserved.